### PR TITLE
Add PTHREAD dependency

### DIFF
--- a/wscript
+++ b/wscript
@@ -24,12 +24,13 @@ def clean_generated(ctx):
     ctx.path.make_node(f).delete()
 
 def configure(conf):
-  conf.env.CXXFLAGS += ['-O2', '-Wall', '-g', '-pipe']
+  conf.env.CXXFLAGS += ['-O2', '-Wall', '-g', '-pipe', '-pthread']
   conf.load('compiler_cxx')
 
   conf.check_cfg(package = 'jubatus', args = '--cflags --libs')
   conf.check_cfg(package = 'jubatus_core', args = '--cflags --libs')
   conf.check_cfg(package = 'jubatus-client', args = '--cflags --libs')
+  conf.check_cxx(lib = 'pthread')
 
 def build(bld):
   bld.program(
@@ -41,7 +42,7 @@ def build(bld):
   bld.program(
     source = name+'_proxy.cpp',
     target = name+'_proxy',
-    use = ['JUBATUS', 'JUBATUS_CORE'],
+    use = ['JUBATUS', 'JUBATUS_CORE', 'PTHREAD'],
     )
 
   bld.program(


### PR DESCRIPTION
I added compiler flags for pthread. This fixes following error.

```
[5/7] cxxprogram: build/kvs_proxy.cpp.1.o -> build/kvs_proxy
/usr/bin/ld: kvs_proxy.cpp.1.o: undefined reference to symbol 'pthread_mutexattr_settype@@GLIBC_2.2.5'
//lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
```
