### PR TITLE
regenerate using latest jenerator

### DIFF
--- a/kvs_client.hpp
+++ b/kvs_client.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from kvs.idl with jenerator version 0.6.4-146-g79178f8/develop
+// This file is auto-generated from kvs.idl with jenerator version 0.9.4-42-g70f7539/develop
 // *** DO NOT EDIT ***
 
 #ifndef KVS_CLIENT_HPP_

--- a/kvs_impl.cpp
+++ b/kvs_impl.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from kvs.idl with jenerator version 0.6.4-146-g79178f8/develop
+// This file is auto-generated from kvs.idl with jenerator version 0.9.4-42-g70f7539/develop
 // *** DO NOT EDIT ***
 
 #include <map>
@@ -96,6 +96,7 @@ class kvs_impl : public jubatus::server::common::mprpc::rpc_server {
 
 int main(int argc, char* argv[]) {
   return
-    jubatus::server::framework::run_server<jubatus::server::kvs_impl>
+    jubatus::server::framework::run_server<jubatus::server::kvs_impl,
+        jubatus::server::kvs_serv>
       (argc, argv, "kvs");
 }

--- a/kvs_proxy.cpp
+++ b/kvs_proxy.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from kvs.idl with jenerator version 0.6.4-146-g79178f8/develop
+// This file is auto-generated from kvs.idl with jenerator version 0.9.4-42-g70f7539/develop
 // *** DO NOT EDIT ***
 
 #include <map>

--- a/kvs_serv.tmpl.cpp
+++ b/kvs_serv.tmpl.cpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from kvs.idl with jenerator version 0.6.4-146-g79178f8/develop
+// This file is auto-generated from kvs.idl with jenerator version 0.9.4-42-g70f7539/develop
 
 #include "kvs_serv.hpp"
 

--- a/kvs_serv.tmpl.hpp
+++ b/kvs_serv.tmpl.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from kvs.idl with jenerator version 0.6.4-146-g79178f8/develop
+// This file is auto-generated from kvs.idl with jenerator version 0.9.4-42-g70f7539/develop
 
 #ifndef KVS_SERV_TMPL_HPP_
 #define KVS_SERV_TMPL_HPP_

--- a/kvs_types.hpp
+++ b/kvs_types.hpp
@@ -1,4 +1,4 @@
-// This file is auto-generated from kvs.idl with jenerator version 0.6.4-146-g79178f8/develop
+// This file is auto-generated from kvs.idl with jenerator version 0.9.4-42-g70f7539/develop
 // *** DO NOT EDIT ***
 
 #ifndef KVS_TYPES_HPP_


### PR DESCRIPTION
We changed server interface in v1.0.0 but did not regenerated the skeleton.
Refs: https://github.com/jubatus/jubatus/pull/1144 and https://github.com/jubatus/jubatus/commit/70f75391f4b310318b658e1bee77cd6abb5fe611